### PR TITLE
Updated SMTP authentication variables

### DIFF
--- a/group_vars/metrics.yml.sample
+++ b/group_vars/metrics.yml.sample
@@ -6,6 +6,8 @@ alertmanager_port: 9093
 alertmanager_listen_address: '' # To listen on all interfaces leave this empty
 alertmanager_smtp_host: localhost
 alertmanager_smtp_port: 25
+alertmanager_smtp_username: '' #To authenticate to local/public smtp server, when applicable
+alertmanager_smtp_password: '' 
 alertmanager_send_email: 'localhost@localhost'
 alertmanager_receive_email:
   - 'localhost@localhost'

--- a/roles/prometheus/templates/alertmanager.yml.j2
+++ b/roles/prometheus/templates/alertmanager.yml.j2
@@ -3,7 +3,10 @@ global:
   smtp_from: {{ alertmanager_send_email }}
   smtp_require_tls: {{ alertmanager_require_tls }}
   resolve_timeout: 5m
-
+{% if alertmanager_smtp_username is defined %}
+  smtp_auth_username: {{ alertmanager_smtp_username }}
+  smtp_auth_password: {{ alertmanager_smtp_password }}
+{% endif %}
 route:
   group_by: ['alertname']
   group_wait: 10s


### PR DESCRIPTION
Added alertmanager_smtp_username and alertmanager_smtp_password variables to metrics.yml.sample

Added these parameters to alertmanager.yml.j2 template, allowing authentication to smtp server