### PR TITLE
add text collector directory to node exporter

### DIFF
--- a/roles/node-exporter/defaults/main.yml
+++ b/roles/node-exporter/defaults/main.yml
@@ -1,3 +1,4 @@
 container_binary: podman
 node_exporter_container_image: prom/node-exporter:latest
 node_exporter_port: 9100
+node_exporter_collector_dir: /var/lib/node_exporter

--- a/roles/node-exporter/tasks/main.yml
+++ b/roles/node-exporter/tasks/main.yml
@@ -6,6 +6,9 @@
     permanent: true
     immediate: true
     state: enabled
-
+- name: make collector directory
+  file:
+    path: "{{ node_exporter_collector_dir }}"
+    state: directory
 - name: include setup_container.yml
   include_tasks: setup_container.yml

--- a/roles/node-exporter/templates/node_exporter.service.j2
+++ b/roles/node-exporter/templates/node_exporter.service.j2
@@ -13,7 +13,7 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f node-exporter
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=node-exporter \
   --privileged \
-  -v /proc:/host/proc:ro -v /sys:/host/sys:ro \
+  -v /proc:/host/proc:ro -v /sys:/host/sys:ro -v {{ node_exporter_collector_dir }}:{{ node_exporter_collector_dir }} \
   --net=host \
   {{ node_exporter_container_image }} \
   --path.procfs=/host/proc \

--- a/roles/node-exporter/templates/node_exporter.service.j2
+++ b/roles/node-exporter/templates/node_exporter.service.j2
@@ -16,7 +16,8 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=node-exporter \
   -v /proc:/host/proc:ro -v /sys:/host/sys:ro -v {{ node_exporter_collector_dir }}:{{ node_exporter_collector_dir }} \
   --net=host \
   {{ node_exporter_container_image }} \
-  --path.procfs=/host/proc \
+  --path.procfs=/host/proc 
+  --collector.textfile.directory={{ node_exporter_collector_dir }} \
   --path.sysfs=/host/sys \
   --no-collector.timex \
   --web.listen-address=:{{ node_exporter_port }}


### PR DESCRIPTION
creates a default directory for node exporter text collectors, to be used for any future scripts. 